### PR TITLE
Extend internal/envvar pkg.

### DIFF
--- a/cmd/weather/deps/client.go
+++ b/cmd/weather/deps/client.go
@@ -1,9 +1,6 @@
 package deps
 
 import (
-	"fmt"
-	"strconv"
-
 	"github.com/danilvpetrov/weathersource/collection"
 	"github.com/danilvpetrov/weathersource/internal/envvar"
 )
@@ -16,24 +13,14 @@ func ProvideClient() (*collection.Client, error) {
 		return nil, err
 	}
 
-	fs, err := envvar.StringRequired("WEATHER_LOC_LATITUDE")
+	lat, err := envvar.Float64Required("WEATHER_LOC_LATITUDE")
 	if err != nil {
 		return nil, err
 	}
 
-	lat, err := strconv.ParseFloat(fs, 64)
-	if err != nil {
-		return nil, fmt.Errorf("cannot convert WEATHER_LOC_LATITUDE to float: %w", err)
-	}
-
-	fs, err = envvar.StringRequired("WEATHER_LOC_LONGITUDE")
+	lon, err := envvar.Float64Required("WEATHER_LOC_LONGITUDE")
 	if err != nil {
 		return nil, err
-	}
-
-	lon, err := strconv.ParseFloat(fs, 64)
-	if err != nil {
-		return nil, fmt.Errorf("cannot convert WEATHER_LOC_LONGITUDE to float: %w", err)
 	}
 
 	cli := collection.NewClient(

--- a/cmd/weather/deps/collector.go
+++ b/cmd/weather/deps/collector.go
@@ -1,7 +1,6 @@
 package deps
 
 import (
-	"fmt"
 	"log"
 	"time"
 
@@ -17,18 +16,12 @@ func ProvideCollector(
 	persister storage.Persister,
 	logger *log.Logger,
 ) (*collection.Collector, error) {
-	d, err := time.ParseDuration(
-		envvar.StringDefault(
-			"WEATHER_UPDATE_INTERVAL",
-			"5m",
-		),
+	d, err := envvar.DurationDefault(
+		"WEATHER_UPDATE_INTERVAL",
+		5*time.Minute,
 	)
 	if err != nil {
-		return nil,
-			fmt.Errorf(
-				"cannot parse WEATHER_UPDATE_INTERVAL as time.Duration: %w",
-				err,
-			)
+		return nil, err
 	}
 
 	bexp := backoff.NewExponentialBackOff()

--- a/internal/envvar/duration.go
+++ b/internal/envvar/duration.go
@@ -1,0 +1,63 @@
+package envvar
+
+import (
+	"os"
+	"time"
+)
+
+// DurationDefault returns the time.Duration value of the environment variable
+// named n, or the default value d if the variable is empty or undefined.
+func DurationDefault(n string, d time.Duration) (time.Duration, error) {
+	v := StringDefault(
+		n,
+		d.String(),
+	)
+
+	dr, err := time.ParseDuration(v)
+	if err != nil {
+		return 0, &ValueParsingError{
+			Name:       n,
+			Value:      v,
+			TargetType: "time.Duration",
+		}
+	}
+
+	return dr, nil
+}
+
+// DurationRequired returns the time.Duration value of the environment variable
+// named n. It returns an error if the variable is empty or undefined.
+func DurationRequired(n string) (time.Duration, error) {
+	if v := String(n); v != "" {
+		dr, err := time.ParseDuration(v)
+		if err != nil {
+			return 0, &ValueParsingError{
+				Name:       n,
+				Value:      v,
+				TargetType: "time.Duration",
+			}
+		}
+
+		return dr, nil
+	}
+
+	return 0, &UndefinedError{n, nil}
+}
+
+// Duration returns the time.Duration value of the environment variable named n.
+func Duration(n string) (time.Duration, error) {
+	validateName(n)
+
+	v := os.Getenv(n)
+
+	dr, err := time.ParseDuration(v)
+	if err != nil {
+		return 0, &ValueParsingError{
+			Name:       n,
+			Value:      v,
+			TargetType: "time.Duration",
+		}
+	}
+
+	return dr, nil
+}

--- a/internal/envvar/error.go
+++ b/internal/envvar/error.go
@@ -49,3 +49,20 @@ func validateName(n string) {
 		panic("environment variable name must not be empty")
 	}
 }
+
+// ValueParsingError is an error that occurs when a value of an environment
+// variable cannot be parsed into the target type.
+type ValueParsingError struct {
+	Name       string
+	Value      string
+	TargetType string
+}
+
+func (e *ValueParsingError) Error() string {
+	return fmt.Sprintf(
+		"'%s' with value '%s' cannot be parsed as '%s'",
+		e.Name,
+		e.Value,
+		e.TargetType,
+	)
+}

--- a/internal/envvar/float.go
+++ b/internal/envvar/float.go
@@ -1,0 +1,63 @@
+package envvar
+
+import (
+	"os"
+	"strconv"
+)
+
+// Float64Default returns the float64 value of the environment variable named n,
+// or the default value d if the variable is empty or undefined.
+func Float64Default(n string, d float64) (float64, error) {
+	v := StringDefault(
+		n,
+		strconv.FormatFloat(d, 'f', -1, 64),
+	)
+
+	f64, err := strconv.ParseFloat(v, 64)
+	if err != nil {
+		return 0, &ValueParsingError{
+			Name:       n,
+			Value:      v,
+			TargetType: "float64",
+		}
+	}
+
+	return f64, nil
+}
+
+// Float64Required returns the float64 value of the environment variable named n.
+// It returns an error if the variable is empty or undefined.
+func Float64Required(n string) (float64, error) {
+	if v := String(n); v != "" {
+		f64, err := strconv.ParseFloat(v, 64)
+		if err != nil {
+			return 0, &ValueParsingError{
+				Name:       n,
+				Value:      v,
+				TargetType: "float64",
+			}
+		}
+
+		return f64, nil
+	}
+
+	return 0, &UndefinedError{n, nil}
+}
+
+// Float64 returns the float64 value of the environment variable named n.
+func Float64(n string) (float64, error) {
+	validateName(n)
+
+	v := os.Getenv(n)
+
+	f64, err := strconv.ParseFloat(v, 64)
+	if err != nil {
+		return 0, &ValueParsingError{
+			Name:       n,
+			Value:      v,
+			TargetType: "float64",
+		}
+	}
+
+	return f64, nil
+}

--- a/internal/envvar/int.go
+++ b/internal/envvar/int.go
@@ -1,0 +1,115 @@
+package envvar
+
+import (
+	"os"
+	"strconv"
+)
+
+// Int64Default returns the int64 value of the environment variable named n,
+// or the default value d if the variable is empty or undefined.
+func Int64Default(n string, d int64) (int64, error) {
+	v := StringDefault(n, string(d))
+
+	i64, err := strconv.ParseInt(v, 10, 64)
+	if err != nil {
+		return 0, &ValueParsingError{
+			Name:       n,
+			Value:      v,
+			TargetType: "int64",
+		}
+	}
+
+	return i64, nil
+}
+
+// Int64Required returns the int64 value of the environment variable named n.
+// It returns an error if the variable is empty or undefined.
+func Int64Required(n string) (int64, error) {
+	if v := String(n); v != "" {
+		i64, err := strconv.ParseInt(v, 10, 64)
+		if err != nil {
+			return 0, &ValueParsingError{
+				Name:       n,
+				Value:      v,
+				TargetType: "int64",
+			}
+		}
+
+		return i64, nil
+	}
+
+	return 0, &UndefinedError{n, nil}
+}
+
+// Int64 returns the int64 value of the environment variable named n.
+func Int64(n string) (int64, error) {
+	validateName(n)
+
+	v := os.Getenv(n)
+
+	i64, err := strconv.ParseInt(v, 10, 64)
+
+	if err != nil {
+		return 0, &ValueParsingError{
+			Name:       n,
+			Value:      v,
+			TargetType: "int64",
+		}
+	}
+
+	return i64, nil
+}
+
+// Uint64Default returns the uint64 value of the environment variable named n,
+// or the default value d if the variable is empty or undefined.
+func Uint64Default(n string, d int64) (uint64, error) {
+	v := StringDefault(n, string(n))
+
+	ui64, err := strconv.ParseUint(v, 10, 64)
+	if err != nil {
+		return 0, &ValueParsingError{
+			Name:       n,
+			Value:      v,
+			TargetType: "uint64",
+		}
+	}
+
+	return ui64, nil
+}
+
+// Uint64Required returns the uint64 value of the environment variable named n.
+// It returns an error if the variable is empty or undefined.
+func Uint64Required(n string) (uint64, error) {
+	if v := String(n); v != "" {
+		ui64, err := strconv.ParseUint(v, 10, 64)
+		if err != nil {
+			return 0, &ValueParsingError{
+				Name:       n,
+				Value:      v,
+				TargetType: "uint64",
+			}
+		}
+
+		return ui64, nil
+	}
+
+	return 0, &UndefinedError{n, nil}
+}
+
+// Uint64 returns the uint64 value of the environment variable named n.
+func Uint64(n string) (uint64, error) {
+	validateName(n)
+
+	v := os.Getenv(n)
+
+	i64, err := strconv.ParseUint(v, 10, 64)
+	if err != nil {
+		return 0, &ValueParsingError{
+			Name:       n,
+			Value:      v,
+			TargetType: "uint64",
+		}
+	}
+
+	return i64, nil
+}


### PR DESCRIPTION
This PR extends `internal/envvar` package with the function to parse `int64`, `uint64`, `float64`, `time.Duration` types from the environment variable values.