### PR TITLE
Add TZ info to Docker image.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,10 @@
-FROM alpine:latest as certs
-RUN apk --update add ca-certificates
+FROM alpine:latest as source
+RUN apk --update add ca-certificates tzdata
 
 FROM scratch
-COPY --from=certs /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
+COPY --from=source /etc/ssl/certs/ /etc/ssl/certs/
+COPY --from=source /usr/share/zoneinfo /usr/share/zoneinfo
+
 
 COPY artifacts/build/release/linux/amd64/weather /app/bin/
 COPY artifacts/build/release/linux/amd64/inflateschema /app/bin/


### PR DESCRIPTION
This PR adds TZ info to the Docker image. It copies it from the 1st stage build image (alpine:latest).