### PR TITLE
Fix retry bug.

### DIFF
--- a/collection/collector.go
+++ b/collection/collector.go
@@ -36,11 +36,20 @@ func (c *Collector) Run(ctx context.Context) error {
 }
 
 func (c *Collector) do(ctx context.Context) error {
+	var (
+		res *Response
+		err error
+	)
+
 	return backoff.RetryNotify(
 		func() error {
-			res, err := c.Client.Forecast(ctx)
-			if err != nil {
-				return err
+			// Don't make a call if the response is already available from
+			// previous retry call.
+			if res == nil {
+				res, err = c.Client.Forecast(ctx)
+				if err != nil {
+					return err
+				}
 			}
 
 			if err := c.Persister.Save(ctx, res.ToData()); err != nil {


### PR DESCRIPTION
This PR fixes a bug that calls Dark Sky API multiple times when retrying the response persistence even though the previous API call was successful. 

The increased API calls t eventually max out free daily usage. 

The solution is to persist the successful API call result into a variable while retrying to persist the response. Eventually when the persistence gets fixed the previous response can finally gets written into the persistence layer.